### PR TITLE
Add support for boolean type pattern hint

### DIFF
--- a/compiledgrok.go
+++ b/compiledgrok.go
@@ -211,6 +211,6 @@ func (compiled CompiledGrok) typeCast(match, key string) (interface{}, error) {
 		return match, nil
 
 	default:
-		return nil, fmt.Errorf("ERROR the value %s cannot be converted to %s. Must be int, float, string or empty", match, typeName)
+		return nil, fmt.Errorf("ERROR the value %s cannot be converted to %s. Must be int, float, bool, string or empty", match, typeName)
 	}
 }

--- a/compiledgrok.go
+++ b/compiledgrok.go
@@ -204,6 +204,9 @@ func (compiled CompiledGrok) typeCast(match, key string) (interface{}, error) {
 	case "float":
 		return strconv.ParseFloat(match, 64)
 
+	case "bool":
+		return strconv.ParseBool(match)
+
 	case "string":
 		return match, nil
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Jeffail/grok
+module github.com/GeorgeGkinis/grok
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/GeorgeGkinis/grok
+module github.com/Jeffail/grok
 
 go 1.15
 

--- a/grok_test.go
+++ b/grok_test.go
@@ -423,11 +423,12 @@ func TestParseTypedWithDefaultCaptureMode(t *testing.T) {
 	g, err := New(Config{NamedCapturesOnly: true})
 	expect.NoError(err)
 
-	captures, err := g.ParseStringTyped("%{IPV4:ip:string} %{NUMBER:status:int} %{NUMBER:duration:float}", `127.0.0.1 200 0.8`)
+	captures, err := g.ParseStringTyped("%{IPV4:ip:string} %{NUMBER:status:int} %{NUMBER:duration:float} %{WORD:boolean:bool}", `127.0.0.1 200 0.8 True`)
 	expect.NoError(err)
 	expect.MapEqual(captures, "ip", "127.0.0.1")
 	expect.MapEqual(captures, "status", 200)
 	expect.MapEqual(captures, "duration", 0.8)
+	expect.MapEqual(captures, "boolean", true)
 }
 
 func TestParseTypedWithNoTypeInfo(t *testing.T) {


### PR DESCRIPTION
This pull request adds support for boolean datatype hints:
%{WORD:boolean_field:bool}